### PR TITLE
Add polling logs flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Options available:
 * `step` (optional) sets timeout between retries to fetch an email
 * `all` (optional) says whether to find a single email or all mathing the query criteria
 * `query` (optional) lets you filter out emails you want to find, you can find more about queries [there](https://support.google.com/mail/answer/7190)
+* `logs` (optional) turns on or off polling logs of attempts to get emails
 
 ### Parse HTML from email
 If your email contains html content - you can parse it and even render it in the browser with a browser automation tool (like [Playwright](https://playwright.dev/docs/api/class-page#page-set-content)):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gmail-getter",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A simple tool that gets emails from the Gmail API",
   "main": "dist/index.js",
   "files": [

--- a/src/api/get-access-token.ts
+++ b/src/api/get-access-token.ts
@@ -37,6 +37,7 @@ export const getAccessToken = async (
     timeout: 15000,
     headers: {'content-type': 'application/x-www-form-urlencoded'},
     data: params,
+    validateStatus: () => true,
   }
 
   let response: AxiosResponse
@@ -46,7 +47,7 @@ export const getAccessToken = async (
   } catch (e) {
     throw new Error(
       `Failed to get Google access token - API request to Google has failed.
-      \n${JSON.stringify(e, null, 2)}`
+        \n${JSON.stringify(e, null, 2)}`
     )
   }
 
@@ -55,7 +56,7 @@ export const getAccessToken = async (
   if (!body) {
     throw new Error(
       `Failed to get Google access token - unable to parse response body.
-      \n${JSON.stringify(response, null, 2)}`
+        \n${JSON.stringify(response, null, 2)}`
     )
   }
 
@@ -64,7 +65,7 @@ export const getAccessToken = async (
   if (!accessToken) {
     throw new Error(
       `Failed to get Google access token - unable to parse access token from the response body.
-      \n${JSON.stringify(body, null, 2)}`
+        \n${JSON.stringify(body, null, 2)}`
     )
   }
 

--- a/src/api/types/emails-list.ts
+++ b/src/api/types/emails-list.ts
@@ -6,7 +6,7 @@ export type Message = {
 }
 
 export type EmailsList = {
-  messages: Message[]
-  nextPageToken: string
+  messages?: Message[]
+  nextPageToken?: string
   resultSizeEstimate: number
 }


### PR DESCRIPTION
New param `logs` is now introduced for `checkInbox` function.

As per request from @chetakkochrekar in https://github.com/bormando/gmail-getter/issues/3, it says whether to log unsuccessful email fetching attempts or not.

By default the param value is `true`.